### PR TITLE
fix sub directory upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 ignore/
 package-lock.json
 yarn.lock
-temp/test*.js
+
+temp
+!temp/.gitkeep
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Project
 ignore/
 package-lock.json
+yarn.lock
 temp/test*.js
 
 # Logs

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,8 @@ $gulp.task('prepare', done => {
 	$fs.writeFileSync($path.resolve(__dirname, './temp/test.js'), content, 'utf8');
 	$fs.writeFileSync($path.resolve(__dirname, './temp/test1.js'), content, 'utf8');
 	$fs.writeFileSync($path.resolve(__dirname, './temp/test2.js'), content, 'utf8');
+	$fs.mkdirSync($path.resolve(__dirname, './temp/dir/sub'), { recursive: true });
+	$fs.writeFileSync($path.resolve(__dirname, './temp/dir/sub/testdir.js'), content, 'utf8');
 	done();
 });
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ const upload = options => {
 	let stream = $through.obj(function (file, encoding, callback) {
 		if (file.isNull()) {
 			callback();
+			return;
 		}
 
 		if (file.isStream()) {
@@ -60,6 +61,7 @@ const upload = options => {
 				new $PluginError(PLUGIN_NAME, 'Streaming not supported')
 			);
 			callback();
+			return;
 		}
 
 		if (!isDir(file.path) && isFile(file.path)) {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const upload = options => {
 
 		if (!isDir(file.path) && isFile(file.path)) {
 			let base = '';
-			if (file.base.indexOf($path.dirname(file.path)) === 0) {
+			if ($path.isAbsolute(file.base)) {
 				base = '';
 			} else {
 				base = file.base;

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const $assert = require('power-assert');
 const $config = require('./config');
 
 const domain = `${$config.Bucket}-${$config.AppId}.coscd.myqcloud.com`;
-const perfix = $config.prefix;
+const prefix = $config.prefix;
 const base = 'base';
 
 const tsContent = $fs.readFileSync($path.resolve(__dirname, '../temp/test.js'), 'utf8');
@@ -16,9 +16,11 @@ describe('check-upload', function () {
 
 	let test1cosRs = null;
 	let test2cosRs = null;
+	let subDircosRs = null;
 
-	const test1CosPath = `http://${domain}/${perfix}/test1.js`;
-	const test2CosPath = `http://${domain}/${perfix}/test2.js`;
+	const test1CosPath = `http://${domain}/${prefix}/test1.js`;
+	const test2CosPath = `http://${domain}/${prefix}/test2.js`;
+	const subDirCosPath = `http://${domain}/${prefix}/dir/sub/testdir.js`;
 
 	before(done => {
 		$rp(test1CosPath).then(rs => {
@@ -28,11 +30,16 @@ describe('check-upload', function () {
 		}).then(rs => {
 			console.log('Remote test2.js content is:', rs);
 			test2cosRs = rs;
+			return $rp(subDirCosPath);
+		}).then(rs => {
+			console.log('Remote testdir.js content is:', rs);
+			subDircosRs = rs;
 			done();
-		}).catch(err => {
-			console.error('check-upload error:', err.message);
-			done();
-		});
+		})
+			.catch(err => {
+				console.error('check-upload error:', err.message);
+				done();
+			});
 	});
 
 	it('File 1 exists', () => {
@@ -44,13 +51,18 @@ describe('check-upload', function () {
 		$assert(typeof test2cosRs === 'string');
 		$assert(test2cosRs.indexOf(tsContent) >= 0);
 	});
+
+	it('File testdir exists', () => {
+		$assert(typeof subDircosRs === 'string');
+		$assert(subDircosRs.indexOf(tsContent) >= 0);
+	});
 });
 
 describe('check-uploadBase', function () {
 	this.timeout(20000);
 
 	let test1cosRs = null;
-	const test1CosPath = `http://${domain}/${perfix}/${base}/test1.js`;
+	const test1CosPath = `http://${domain}/${prefix}/${base}/test1.js`;
 
 	before(done => {
 		$rp(test1CosPath).then(rs => {


### PR DESCRIPTION
- 修复 `callback` 后需要 `return`，否则会多次调用 `callback` 导致报错；
- 修复 不传 base 参数时，默认值为 `cwd`，导致路径出问题。
